### PR TITLE
[Feature] Voter 컨트롤러 테스트 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/voter/controller/VoterController.kt
+++ b/backend/src/main/java/com/example/backend/domain/voter/controller/VoterController.kt
@@ -42,7 +42,7 @@ class VoterController(
 	): ResponseEntity<Void> {
 		logger.info("Voter removal requested: groupId={}, voteId={}, memberId={}", groupId, voteId, customUserDetails.userId)
 		voterService.removeVoter(groupId, voteId, customUserDetails.userId)
-		return ResponseEntity.ok().build()
+		return ResponseEntity.noContent().build() // '204 No Content' 반환
 	}
 
 	@GetMapping("/group/{groupId}")

--- a/backend/src/test/java/com/example/backend/test/voter/VoterControllerTest.kt
+++ b/backend/src/test/java/com/example/backend/test/voter/VoterControllerTest.kt
@@ -1,0 +1,174 @@
+package com.example.backend.test.voter
+
+import com.example.backend.domain.group.entity.Group
+import com.example.backend.domain.group.entity.GroupStatus
+import com.example.backend.domain.group.repository.GroupRepository
+import com.example.backend.domain.groupmember.entity.GroupMember
+import com.example.backend.domain.groupmember.repository.GroupMemberRepository
+import com.example.backend.domain.member.entity.Member
+import com.example.backend.domain.member.repository.MemberRepository
+import com.example.backend.domain.vote.entity.Vote
+import com.example.backend.domain.vote.repository.VoteRepository
+import com.example.backend.global.util.TestTokenProvider
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class VoterControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var groupRepository: GroupRepository
+
+    @Autowired
+    private lateinit var voteRepository: VoteRepository
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var groupMemberRepository: GroupMemberRepository
+
+    @Autowired
+    private lateinit var tokenProvider: TestTokenProvider
+
+    @PersistenceContext
+    private lateinit var em: EntityManager
+
+    private lateinit var group: Group
+    private lateinit var vote: Vote
+    private lateinit var member: Member
+    private lateinit var accessToken: String
+
+    @BeforeEach // 각 테스트 메서드가 실행되기 전에 매번 실행
+    fun setUp() {
+
+        // 테스트 데이터 초기화 및 DB 재설정
+        memberRepository.deleteAll()
+        groupRepository.deleteAll()
+        em.createNativeQuery("ALTER TABLE member ALTER COLUMN id RESTART WITH 1").executeUpdate()
+        em.createNativeQuery("ALTER TABLE \"groups\" ALTER COLUMN id RESTART WITH 1").executeUpdate()
+
+        // 테스트에 사용할 멤버 생성 및 저장
+        member = memberRepository.save(
+            Member(email = "test@example.com", nickname = "테스트 유저", kakaoId = 123456789)
+        )
+
+        // 멤버가 포함된 그룹을 생성 및 저장
+        group = groupRepository.save(
+            Group(
+                title = "테스트 그룹",
+                description = "테스트 그룹 설명",
+                maxParticipants = 10,
+                status = GroupStatus.RECRUITING,
+                member = member
+            )
+        )
+
+
+        // 그룹에 멤버 추가
+        groupMemberRepository.save(GroupMember(group = group, member = member))
+
+
+        // 특정 그룹과 연결된 투표를 생성하여 저장
+        vote = voteRepository.save(
+            Vote(
+                groupId = group.id!!,
+                location = "테스트 장소",
+                address = "테스트 주소",
+                latitude = 37.1234,
+                longitude = 127.1234
+            )
+        )
+
+        // 테스트 요청 시 필요한 인증을 위해 JWT 액세스 토큰 생성
+        accessToken = tokenProvider.generateMemberAccessToken(
+            member.id!!, member.nickname, member.email
+        )
+    }
+
+    @Test
+    @DisplayName("투표자 등록 성공")
+    fun addVoter_Success() {
+        // JWT 인증을 위한 쿠키 생성
+        val accessTokenCookie = Cookie("accessToken", accessToken)
+
+        // 투표자 등록 요청을 실행하고 200 OK 응답을 기대
+        mockMvc.perform(
+            post("/voters/${group.id}/${vote.id}")
+                .cookie(accessTokenCookie) // 인증 쿠키 추가
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("투표자 조회 성공")
+    fun getVotersByVote_Success() {
+        // JWT 인증을 위한 쿠키 생성
+        val accessTokenCookie = Cookie("accessToken", accessToken)
+
+        // 테스트를 위해 투표자 추가
+        mockMvc.perform(
+            post("/voters/${group.id}/${vote.id}")
+                .cookie(accessTokenCookie)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+
+        // 투표에 참여한 멤버 목록을 조회하고 200 OK 응답을 기대
+        mockMvc.perform(
+            get("/voters/${vote.id}")
+                .cookie(accessTokenCookie)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("투표자 삭제 성공")
+    fun removeVoter_Success() {
+        // JWT 인증을 위한 쿠키 생성
+        val accessTokenCookie = Cookie("accessToken", accessToken)
+
+        // 삭제 테스트 전에 투표자를 먼저 등록하여 상태를 세팅
+        mockMvc.perform(
+            post("/voters/${group.id}/${vote.id}")
+                .cookie(accessTokenCookie)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isOk)  // 정상적으로 추가되었는지 확인
+
+        // 등록된 투표자를 삭제 요청하여 204 No Content 응답을 기대
+        mockMvc.perform(
+            delete("/voters/${group.id}/${vote.id}")
+                .cookie(accessTokenCookie) // 인증 쿠키 추가
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andDo(print())
+            .andExpect(status().isNoContent)
+    }
+}


### PR DESCRIPTION
- [x] 투표자 등록 테스트
- [x] 투표자 조회 테스트
- [x] 투표자 삭제 테스트

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

투표자 등록 테스트와 투표자 삭제 테스트를 실행하고 HTTP 상태 코드가 자꾸 다르게 나오길래 고칠려고 씨름하느라 시간이 꽤나 걸렸네요 ㅠ
알고보니 제가 놓치고 생각한 부분들이 있어 추가하고 수정하니 갑자기 급 해결됐습니다. 😂

1) 투표자 등록 실패 (409 Conflict)

실패 원인: 테스트 실행 시 setUp()에서 Voter가 이미 등록된 상태로 테스트가 시작되었습니다. 이전코드는 setUp()에서 voterRepository.save()를 실행하고 있기 때문에, Voter가 이미 존재한 상태에서 테스트가 실행되었더라구요.

=> 해서 setUp()에서 Voter를 초기 데이터로 등록하지 않도록 수정했습니다.
테스트 실행 전 Voter가 존재하지 않도록 변경해서 테스트 성공했습니다.

2) 투표자 삭제 테스트 실패 (200 vs 204)

실패 원인: VoterController에서 ResponseEntity<Void>를 반환하는데, HttpStatus.NO_CONTENT (204) 대신 HttpStatus.OK (200)을 사용하고 있었습니다....
때문에 removeVoter_Success() 테스트에서 기대하는 응답 코드가 204(No Content)인데, 실제로는 200(OK)이 반환되고 있었습니다.

=> VoterController에서 return 값 수정해서 204로 리턴하도록 코드 수정했습니다.


## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

추가 기능으로는 그룹에 참여한 인원들끼리 Spring WebSocket + Redis 를 활용한 실시간 채팅 기능을 구현해보려고 합니다!
(이제 조사하고 시작하는 단계라는 점 참고 부탁드립니다..!)
