### PR TITLE
Feature/member-43 Member 엔티티에서 리프레시 토큰 관리 -> redis에서 관리로 로직 변경

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberTokenReissueDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberTokenReissueDto.kt
@@ -14,12 +14,12 @@ data class MemberTokenReissueDto(
     val refreshToken: String
 ) {
     companion object {
-        fun of(member: Member): MemberTokenReissueDto {
+        fun of(member: Member, reIssuedRefreshToken: String): MemberTokenReissueDto {
             return MemberTokenReissueDto(
                 member.id!!,
                 member.nickname,
                 member.email,
-                member.kakaoRefreshToken
+                reIssuedRefreshToken
             )
         }
     }

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberTokenReissueDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberTokenReissueDto.kt
@@ -1,7 +1,5 @@
 package com.example.backend.domain.member.dto
 
-import com.example.backend.domain.member.entity.Member
-
 /**
  * MemberTokenReissueDto
  * 토큰 갱신할 때 사용할 리프레시토큰까지 갖는 Dto
@@ -14,11 +12,11 @@ data class MemberTokenReissueDto(
     val refreshToken: String
 ) {
     companion object {
-        fun of(member: Member, reIssuedRefreshToken: String): MemberTokenReissueDto {
+        fun of(memberInfoDto: MemberInfoDto, reIssuedRefreshToken: String): MemberTokenReissueDto {
             return MemberTokenReissueDto(
-                member.id!!,
-                member.nickname,
-                member.email,
+                memberInfoDto.id,
+                memberInfoDto.nickname,
+                memberInfoDto.email,
                 reIssuedRefreshToken
             )
         }

--- a/backend/src/main/java/com/example/backend/domain/member/repository/MemberRepository.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/repository/MemberRepository.kt
@@ -19,6 +19,4 @@ interface MemberRepository : JpaRepository<Member, Long> {
                 "FROM Member m WHERE m.id = :id"
     )
     fun findMemberInfoDtoById(id: Long): Optional<MemberInfoDto>
-
-    fun findByKakaoRefreshToken(kakaoRefreshToken: String): Optional<Member>
 }

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.kt
@@ -1,10 +1,8 @@
 package com.example.backend.domain.member.service
 
 import com.example.backend.domain.member.dto.MemberInfoDto
-import com.example.backend.domain.member.dto.MemberInfoDto.Companion.of
 import com.example.backend.domain.member.dto.MemberModifyRequestDto
 import com.example.backend.domain.member.entity.Member
-import com.example.backend.domain.member.entity.Member.Companion.of
 import com.example.backend.domain.member.exception.MemberErrorCode
 import com.example.backend.domain.member.exception.MemberException
 import com.example.backend.domain.member.repository.MemberRepository
@@ -54,16 +52,7 @@ class MemberService(
 
     @Transactional
     fun join(kakaoUserInfoDto: KakaoUserInfoResponseDto) {
-        memberRepository.save(of(kakaoUserInfoDto))
-    }
-
-    @Transactional(readOnly = true)
-    fun findByKakaoRefreshToken(refreshToken: String): Member {
-        return memberRepository.findByKakaoRefreshToken(refreshToken).orElseThrow {
-            MemberException(
-                MemberErrorCode.MEMBER_NOT_FOUND
-            )
-        }
+        memberRepository.save(Member.of(kakaoUserInfoDto))
     }
 
     @Transactional

--- a/backend/src/main/java/com/example/backend/global/auth/kakao/exception/KakaoAuthErrorCode.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/kakao/exception/KakaoAuthErrorCode.kt
@@ -15,5 +15,6 @@ enum class KakaoAuthErrorCode(
 
     KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "카카오 서버에서 알 수 없는 오류가 발생했습니다."),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "400-1", "잘못된 쿼리 파라미터가 설정되었습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "401-2", "토큰이 존재하지 않습니다."),
     TOKEN_REISSUE_FAILED(HttpStatus.UNAUTHORIZED, "401-1", "토큰 갱신에 실패했습니다.");
 }

--- a/backend/src/main/java/com/example/backend/global/auth/kakao/util/KakaoAuthUtil.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/kakao/util/KakaoAuthUtil.kt
@@ -57,11 +57,10 @@ class KakaoAuthUtil(
         return userInfoUri
     }
 
-    fun getLogoutUrl(userId: Long): String {
+    fun getLogoutUrl(): String {
         return UriComponentsBuilder.fromUriString(kakaoLogoutUrl)
             .queryParam("client_id", clientId)
             .queryParam("logout_redirect_uri", kakaoLogoutRedirectUri)
-            .queryParam("state", userId)
             .toUriString()
     }
 

--- a/backend/src/main/java/com/example/backend/global/auth/service/CookieService.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/service/CookieService.kt
@@ -5,6 +5,7 @@ import com.example.backend.global.auth.util.JwtUtil
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 
 /**
  * CookieService
@@ -20,14 +21,23 @@ class CookieService(
     fun addAccessTokenToCookie(accessToken: String, response: HttpServletResponse) {
         cookieUtil.addTokenToCookie(
             "accessToken", accessToken,
-            jwtUtil.getAccessTokenExpirationTime(), response
+            TimeUnit.MILLISECONDS.toSeconds(jwtUtil.getAccessTokenExpirationTime()),
+            response
         )
     }
 
     fun addRefreshTokenToCookie(refreshToken: String, response: HttpServletResponse) {
         cookieUtil.addTokenToCookie(
             "refreshToken", refreshToken,
-            jwtUtil.getRefreshTokenExpirationTime(), response
+            TimeUnit.MILLISECONDS.toSeconds(jwtUtil.getRefreshTokenExpirationTime()),
+            response
+        )
+    }
+
+    fun addRefreshTokenToCookieWithSameSiteNone(refreshToken: String, response: HttpServletResponse) {
+        cookieUtil.addTokenToCookieWithSameSiteNone(
+            "refreshToken", refreshToken,
+            TimeUnit.MILLISECONDS.toSeconds(jwtUtil.getRefreshTokenExpirationTime()), response
         )
     }
 

--- a/backend/src/main/java/com/example/backend/global/auth/util/CookieUtil.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/util/CookieUtil.kt
@@ -31,6 +31,18 @@ class CookieUtil {
         response.addHeader("Set-Cookie", cookie.toString())
     }
 
+    fun addTokenToCookieWithSameSiteNone(name: String, value: String, expiration: Long, response: HttpServletResponse) {
+        val cookie = ResponseCookie.from(name, value)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .sameSite("None")
+            .maxAge(expiration)
+            .build()
+
+        response.addHeader("Set-Cookie", cookie.toString())
+    }
+
     /**
      * 쿠키에서 name의 토큰을 받아오는 메서드
      * @param name

--- a/backend/src/test/java/com/example/backend/domain/member/MemberRepositoryTest.kt
+++ b/backend/src/test/java/com/example/backend/domain/member/MemberRepositoryTest.kt
@@ -180,41 +180,4 @@ class MemberRepositoryTest {
         // then
         assertThat(optionalMemberInfoDto.isPresent).isFalse
     }
-
-    @Test
-    @DisplayName("findByKakaoRefreshToken 성공 테스트")
-    fun findByKakaoRefreshTokenSuccessTest() {
-        // given
-        val refreshToken = "testRefreshToken.abcdefghijklmnopqrstuvwxyz.1234567890"
-        member.updateRefreshToken(refreshToken)
-
-        val optionalMember = memberRepository.findByKakaoRefreshToken(refreshToken)
-
-        // when
-        assertThat(optionalMember.isPresent).isTrue
-        val member = optionalMember.get()
-
-        // then
-        assertThat(member.id).isEqualTo(1L)
-        assertThat(member.kakaoId).isEqualTo(1L)
-        assertThat(member.nickname).isEqualTo("testUser")
-        assertThat(member.email).isEqualTo("test@test.com")
-        assertThat(member.kakaoRefreshToken).isEqualTo(refreshToken)
-
-    }
-
-    @Test
-    @DisplayName("findByKakaoRefreshToken 실패 테스트 - 존재하지 않는 refreshToken으로 조회 시도")
-    fun findByKakaoRefreshTokenFailTest_WhenMemberNotExists() {
-        // given
-        val refreshToken = "testRefreshToken.abcdefghijklmnopqrstuvwxyz.1234567890"
-        member.updateRefreshToken(refreshToken)
-
-        // when
-        val blankRefreshToken = ""
-        val optionalMember = memberRepository.findByKakaoRefreshToken(blankRefreshToken)
-
-        //then
-        assertThat(optionalMember.isPresent).isFalse
-    }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### Member 엔티티에서 리프레시 토큰 관리 -> redis에서 관리로 로직 변경

### 로그아웃, 토큰 재발급 로직 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- [x]  로그인 시 리프레시 토큰이 redis에 저장되도록 변경
  - [{$refreshtoken}: "kakao: "{$member.id}]

- [x] 리프레시 토큰이 저장되는 쿠키의 설정 변경(카카오 서버와 통신중에도 쿠키가 유지되도록)
- [x] 로그아웃 시 리프레시 토큰을 redis에서 삭제 
- [x] 토큰 재발급 시 리프레시 토큰을 사용해서 redis에서 member.id 파싱
- [x] 인증 도중 에러 발생으로 인해 강제 로그아웃 시 레디스에 리프레시 토큰까지 삭제
- [x] 쿠키 설정에서 maxAge의 단위가 잘못되어있던 점 수정(밀리초 -> 초)


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
