### PR TITLE
[Feature] 그룹 조회수 카운팅

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/group/controller/GroupController.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/controller/GroupController.kt
@@ -2,6 +2,7 @@ package com.example.backend.domain.group.controller;
 
 import com.example.backend.domain.group.dto.*
 import com.example.backend.domain.group.service.GroupService
+import com.example.backend.domain.group.service.GroupViewService
 import com.example.backend.global.auth.model.CustomUserDetails
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +18,8 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/groups")
 class GroupController(
-    private val groupService: GroupService
+    private val groupService: GroupService,
+    private val groupViewService: GroupViewService
 ) {
     @PostMapping
     fun createGroup (
@@ -40,6 +42,7 @@ class GroupController(
     @GetMapping("/{groupId}")
     fun getGroup(@PathVariable("groupId") id : Long) : ResponseEntity<GroupResponseDto>{
         log.info("Getting group by groupId {}$id");
+        groupViewService.incrementViewCount(id);
         val response : GroupResponseDto = groupService.findGroup(id)
         return  ResponseEntity(response, HttpStatusCode.valueOf(200))
     }

--- a/backend/src/main/java/com/example/backend/domain/group/controller/GroupController.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/controller/GroupController.kt
@@ -40,9 +40,10 @@ class GroupController(
     }
 
     @GetMapping("/{groupId}")
-    fun getGroup(@PathVariable("groupId") id : Long) : ResponseEntity<GroupResponseDto>{
+    fun getGroup(@PathVariable("groupId") id : Long, @AuthenticationPrincipal customUserDetails : CustomUserDetails) : ResponseEntity<GroupResponseDto>{
         log.info("Getting group by groupId {}$id");
-        groupViewService.incrementViewCount(id);
+        val memberId : Long = customUserDetails.userId
+        groupViewService.incrementViewCount(id,memberId);
         val response : GroupResponseDto = groupService.findGroup(id)
         return  ResponseEntity(response, HttpStatusCode.valueOf(200))
     }

--- a/backend/src/main/java/com/example/backend/domain/group/dto/GroupResponseDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/dto/GroupResponseDto.kt
@@ -15,7 +15,8 @@ data class GroupResponseDto(
     val status : GroupStatus,
     val category : List<CategoryResponseDto>,
     val createdAt : LocalDateTime,
-    val modifiedAt : LocalDateTime
+    val modifiedAt : LocalDateTime,
+    val viewCount : Long
 ) {
     constructor(group: Group) : this(
         id = group.id,
@@ -27,6 +28,20 @@ data class GroupResponseDto(
         status = group.status,
         category = group.groupCategories.map { CategoryResponseDto(it.category) },
         createdAt = group.createdAt!!,
-        modifiedAt = group.modifiedAt!!
+        modifiedAt = group.modifiedAt!!,
+        viewCount = 0
+    )
+    constructor(group: Group, viewCount: Long) : this(
+        id = group.id,
+        title = group.title,
+        description = group.description,
+        memberId = group.member.id!!,
+        author = group.member.nickname,
+        maxParticipants = group.maxParticipants,
+        status = group.status,
+        category = group.groupCategories.map { CategoryResponseDto(it.category) },
+        createdAt = group.createdAt!!,
+        modifiedAt = group.modifiedAt!!,
+        viewCount = viewCount
     )
 }

--- a/backend/src/main/java/com/example/backend/domain/group/service/GroupService.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/service/GroupService.kt
@@ -33,7 +33,8 @@ class GroupService(
     val categoryRepository: CategoryRepository,
     val voteRepository: VoteRepository,
     val voterRepository: VoterRepository,
-    private val voteService: VoteService
+    private val voteService: VoteService,
+    private val groupViewService: GroupViewService
 ) {
     @Transactional
     fun create(groupRequestDto : GroupRequestDto, id : Long) : GroupResponseDto{
@@ -70,7 +71,10 @@ class GroupService(
 
     @Transactional(readOnly = true)
     fun findGroup(id : Long) : GroupResponseDto{
-        return groupRepository.findById(id).map{GroupResponseDto(it)}.orElseThrow{throw GroupException(GroupErrorCode.NOT_FOUND)}
+        val group = groupRepository.findById(id)
+            .orElseThrow { throw GroupException(GroupErrorCode.NOT_FOUND) }
+        val viewCount = groupViewService.getViewCount(id)
+        return GroupResponseDto(group, viewCount)
     }
 
 

--- a/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
@@ -12,4 +12,9 @@ class GroupViewService(private val redisTemplate: StringRedisTemplate) {
         val key = "$viewKeyPrefix$groupId"
         redisTemplate.opsForValue().increment(key)
     }
+
+    fun getViewCount(groupId: Long): Long {
+        val key = "$viewKeyPrefix$groupId"
+        return redisTemplate.opsForValue().get(key)?.toLong() ?: 0
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
@@ -2,16 +2,24 @@ package com.example.backend.domain.group.service
 
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 
 @Service
 class GroupViewService(private val redisTemplate: StringRedisTemplate) {
 
     private val viewKeyPrefix = "group:views:"
+    private val userViewedPrefix = "group:user:viewed:"
 
-    fun incrementViewCount(groupId: Long) {
-        val key = "$viewKeyPrefix$groupId"
-        redisTemplate.opsForValue().increment(key)
+    fun incrementViewCount(groupId: Long, userId: Long) {
+        val groupKey = "$viewKeyPrefix$groupId"
+        val userViewKey = "$userViewedPrefix$groupId:$userId"
+
+        if (redisTemplate.opsForValue().get(userViewKey) == null) {
+            redisTemplate.opsForValue().increment(groupKey)
+            redisTemplate.opsForValue().set(userViewKey, "viewed", 24, TimeUnit.HOURS) // 24시간 동안만 조회한 것으로 처리
+        }
     }
+
 
     fun getViewCount(groupId: Long): Long {
         val key = "$viewKeyPrefix$groupId"

--- a/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
@@ -1,9 +1,12 @@
 package com.example.backend.domain.group.service
 
+import lombok.extern.slf4j.Slf4j
+import org.hibernate.query.sqm.tree.SqmNode.log
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import java.util.concurrent.TimeUnit
 
+@Slf4j
 @Service
 class GroupViewService(private val redisTemplate: StringRedisTemplate) {
 
@@ -14,6 +17,8 @@ class GroupViewService(private val redisTemplate: StringRedisTemplate) {
         val groupKey = "$viewKeyPrefix$groupId"
         val userViewKey = "$userViewedPrefix$groupId:$userId"
 
+        log.info("groupkey는 : $groupKey")
+        log.info("userKey는 : $userViewKey")
         if (redisTemplate.opsForValue().get(userViewKey) == null) {
             redisTemplate.opsForValue().increment(groupKey)
             redisTemplate.opsForValue().set(userViewKey, "viewed", 24, TimeUnit.HOURS) // 24시간 동안만 조회한 것으로 처리

--- a/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
@@ -1,0 +1,15 @@
+package com.example.backend.domain.group.service
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class GroupViewService(private val redisTemplate: StringRedisTemplate) {
+
+    private val viewKeyPrefix = "group:views:"
+
+    fun incrementViewCount(groupId: Long) {
+        val key = "$viewKeyPrefix$groupId"
+        redisTemplate.opsForValue().increment(key)
+    }
+}

--- a/backend/src/main/java/com/example/backend/global/auth/jwt/MemberAuthFilter.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/jwt/MemberAuthFilter.kt
@@ -103,6 +103,7 @@ class MemberAuthFilter(
         return !(
                 (path == "/groups/member" && method == "GET") ||
                         (path == "/groups/location" && method == "GET") ||
+                        (path.startsWith("/groups/") && method == "GET") ||
                         (path.startsWith("/groups") && method in setOf("POST", "PUT", "DELETE")) ||
                         path.startsWith("/members") ||
                         path.startsWith("/votes") ||

--- a/frontend/src/app/groups/[id]/page.tsx
+++ b/frontend/src/app/groups/[id]/page.tsx
@@ -22,6 +22,7 @@ type GroupDetail = {
     memberId: number;
     description: string;
     field: Category[];
+    viewCount: number;
 };
 
 export default function GroupDetailPage() {
@@ -74,6 +75,7 @@ export default function GroupDetailPage() {
                         field: Array.isArray(groupData.category)
                             ? groupData.category
                             : [groupData.category],
+                        viewCount: groupData.viewCount || 0,
                     });
                 }
             } catch (error) {
@@ -168,6 +170,12 @@ export default function GroupDetailPage() {
                                 ))}
                             </div>
                         </div>
+                    </div>
+
+                    {/* 조회수 표시 */}
+                    <div className="flex items-center space-x-2 mt-4">
+                        <span className="font-semibold text-gray-900">조회수</span>
+                        <span className="text-gray-700">{group.viewCount}회</span> {/* 조회수 출력 */}
                     </div>
 
                     {/* 프로젝트 설명 */}


### PR DESCRIPTION
## 📌 과제 설명 

조회수 카운팅 구현했습니다. (백 / 프론트 둘다 구현했습니다)
close : #44 

그룹(모임)클릭시 조회수 카운팅
- 각 게시물에 대하여 24시간동안 한번만 조회수 올릴 수 있음

- group response dto만 수정하고, group entity자체는 변경사항없습니다! (조회수는 mysql db에 저장되지 않아요)