### PR TITLE
Feature/cache-55 카테고리 전체 조회 및 특정 그룹의 투표 조회 캐싱, 리팩토링 진행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 #.gitignore yml 로컬 프로필 설정
 backend/src/main/resources/application-local.yml
 backend/src/main/resources/application-test.yml
+backend/src/test/resources/application-test.yml
 
 #OS
 .DS_Store

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,10 +36,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web-services")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
 
-    compileOnly("org.projectlombok:lombok")
-    annotationProcessor("org.projectlombok:lombok")
-    testCompileOnly("org.projectlombok:lombok")
-    testAnnotationProcessor("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
     runtimeOnly("com.h2database:h2")
@@ -52,6 +48,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/backend/src/main/java/com/example/backend/domain/admin/controller/AdminController.kt
+++ b/backend/src/main/java/com/example/backend/domain/admin/controller/AdminController.kt
@@ -69,6 +69,6 @@ class AdminController(
 	@GetMapping("/members/search")
 	fun getMembersByNickName(@RequestParam nickname: String , response: HttpServletResponse): ResponseEntity<ApiResponse<List<MemberInfoDto>>> {
 		val memberInfoDtoList = adminService.findMemberInfoDtosByNickname(nickname)
-		return ResponseEntity.ok().body(ApiResponse.of(memberInfoDtoList))
+		return ResponseEntity.ok().body(ApiResponse(memberInfoDtoList))
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/category/dto/CategoryResponseDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/category/dto/CategoryResponseDto.kt
@@ -2,11 +2,12 @@ package com.example.backend.domain.category.dto
 
 import com.example.backend.domain.category.entity.Category
 import com.example.backend.domain.category.entity.CategoryType
+import com.fasterxml.jackson.annotation.JsonProperty
 
 data class CategoryResponseDto(
-    val id: Long?,
-    val type: CategoryType,
-    val name: String
+    @JsonProperty("id") val id: Long?,
+    @JsonProperty("type") val type: CategoryType,
+    @JsonProperty("name") val name: String
 ) {
     constructor(category: Category) : this(
         id = category.id,

--- a/backend/src/main/java/com/example/backend/domain/category/service/CategoryService.kt
+++ b/backend/src/main/java/com/example/backend/domain/category/service/CategoryService.kt
@@ -6,6 +6,8 @@ import com.example.backend.domain.category.entity.Category
 import com.example.backend.domain.category.exception.CategoryErrorCode
 import com.example.backend.domain.category.exception.CategoryException
 import com.example.backend.domain.category.repository.CategoryRepository
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,6 +17,7 @@ class CategoryService(
 ) {
 
     @Transactional
+    @CacheEvict(value = ["categories"], allEntries = true)
     fun create(requestDto: CategoryRequestDto): CategoryResponseDto {
         val category = Category(
             name = requestDto.name,
@@ -25,6 +28,7 @@ class CategoryService(
     }
 
     @Transactional
+    @CacheEvict(value = ["categories"], allEntries = true)
     fun modify(id: Long, categoryRequestDto: CategoryRequestDto): CategoryResponseDto {
         val category = categoryRepository.findById(id)
             .orElseThrow { CategoryException(CategoryErrorCode.NOT_FOUND) }
@@ -38,6 +42,7 @@ class CategoryService(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = ["categories"])
     fun getAllCategories(): List<CategoryResponseDto> {
         val categories = categoryRepository.findAll()
         if (categories.isEmpty()) {
@@ -54,6 +59,7 @@ class CategoryService(
     }
 
     @Transactional
+    @CacheEvict(value = ["categories"], allEntries = true)
     fun delete(id: Long) {
         val category = categoryRepository.findById(id)
             .orElseThrow { CategoryException(CategoryErrorCode.NOT_FOUND) }

--- a/backend/src/main/java/com/example/backend/domain/group/controller/GroupController.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/controller/GroupController.kt
@@ -5,7 +5,6 @@ import com.example.backend.domain.group.service.GroupService
 import com.example.backend.domain.group.service.GroupViewService
 import com.example.backend.global.auth.model.CustomUserDetails
 import jakarta.validation.Valid;
-import lombok.extern.slf4j.Slf4j;
 import org.hibernate.query.sqm.tree.SqmNode.log
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode
@@ -14,7 +13,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
-@Slf4j
 @RestController
 @RequestMapping("/groups")
 class GroupController(

--- a/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
+++ b/backend/src/main/java/com/example/backend/domain/group/service/GroupViewService.kt
@@ -1,13 +1,13 @@
 package com.example.backend.domain.group.service
 
 import com.example.backend.global.redis.service.RedisService
-import lombok.extern.slf4j.Slf4j
-import org.hibernate.query.sqm.tree.SqmNode.log
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
-@Slf4j
 @Service
 class GroupViewService(private val redisService: RedisService) {
+
+    private val log = LoggerFactory.getLogger(GroupViewService::class.java)
 
     private val viewKeyPrefix = "group:views:"
     private val userViewedPrefix = "group:user:viewed:"

--- a/backend/src/main/java/com/example/backend/domain/groupmember/entity/GroupMember.kt
+++ b/backend/src/main/java/com/example/backend/domain/groupmember/entity/GroupMember.kt
@@ -4,8 +4,6 @@ import com.example.backend.domain.group.entity.Group
 import com.example.backend.domain.member.entity.Member
 import com.example.backend.global.base.BaseEntity
 import jakarta.persistence.*
-import lombok.Getter
-import lombok.NoArgsConstructor
 
 @Entity
 class GroupMember : BaseEntity {

--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.kt
@@ -22,11 +22,7 @@ class MemberController(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails
     ): ResponseEntity<ApiResponse<MemberInfoDto>> {
 
-        val memberDto = MemberInfoDto(
-            customUserDetails.userId,
-            customUserDetails.username,
-            customUserDetails.email
-        )
+        val memberDto = MemberInfoDto(customUserDetails)
         return ResponseEntity.ok().body(ApiResponse.of(memberDto))
     }
 

--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.kt
@@ -23,7 +23,7 @@ class MemberController(
     ): ResponseEntity<ApiResponse<MemberInfoDto>> {
 
         val memberDto = MemberInfoDto(customUserDetails)
-        return ResponseEntity.ok().body(ApiResponse.of(memberDto))
+        return ResponseEntity.ok().body(ApiResponse(memberDto))
     }
 
     @PutMapping
@@ -34,6 +34,6 @@ class MemberController(
     ): ResponseEntity<ApiResponse<MemberInfoDto>> {
 
         val memberInfoDto = memberService.modify(customUserDetails.userId, memberModifyDto, response)
-        return ResponseEntity.ok().body(ApiResponse.of(memberInfoDto))
+        return ResponseEntity.ok().body(ApiResponse(memberInfoDto))
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoDto.kt
@@ -1,6 +1,7 @@
 package com.example.backend.domain.member.dto
 
 import com.example.backend.domain.member.entity.Member
+import com.example.backend.global.auth.model.CustomUserDetails
 
 /**
  * MemberInfoDto
@@ -12,13 +13,16 @@ data class MemberInfoDto(
     val nickname: String,
     val email: String
 ) {
-    companion object {
-        fun of(member: Member): MemberInfoDto {
-            return MemberInfoDto(
-                id = member.id!!,
-                nickname = member.nickname,
-                email = member.email
-            )
-        }
-    }
+
+    constructor(member: Member) : this(
+        id = member.id!!,
+        nickname = member.nickname,
+        email = member.email
+    )
+
+    constructor(customUserDetails: CustomUserDetails) : this(
+        id = customUserDetails.userId,
+        nickname = customUserDetails.username,
+        email = customUserDetails.email
+    )
 }

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberTokenReissueDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberTokenReissueDto.kt
@@ -11,14 +11,11 @@ data class MemberTokenReissueDto(
     val email: String,
     val refreshToken: String
 ) {
-    companion object {
-        fun of(memberInfoDto: MemberInfoDto, reIssuedRefreshToken: String): MemberTokenReissueDto {
-            return MemberTokenReissueDto(
-                memberInfoDto.id,
-                memberInfoDto.nickname,
-                memberInfoDto.email,
-                reIssuedRefreshToken
-            )
-        }
-    }
+
+    constructor(memberInfoDto: MemberInfoDto, reIssuedRefreshToken: String) : this(
+        memberInfoDto.id,
+        memberInfoDto.nickname,
+        memberInfoDto.email,
+        reIssuedRefreshToken
+    )
 }

--- a/backend/src/main/java/com/example/backend/domain/member/entity/Member.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/entity/Member.kt
@@ -21,19 +21,12 @@ class Member(
     @Column(name = "kakao_refresh_token")
     var kakaoRefreshToken: String = ""
 
-    companion object {
-        fun of(kakaoUserInfoDto: KakaoUserInfoResponseDto): Member {
-            return Member(
-                kakaoId = kakaoUserInfoDto.id,
-                nickname = kakaoUserInfoDto.properties.nickname,
-                email = kakaoUserInfoDto.kakaoAccount.email
-            )
-        }
-    }
+    constructor(kakaoUserInfoDto: KakaoUserInfoResponseDto) : this(
+        kakaoId = kakaoUserInfoDto.id,
+        nickname = kakaoUserInfoDto.properties.nickname,
+        email = kakaoUserInfoDto.kakaoAccount.email
+    )
 
-    fun updateRefreshToken(refreshToken: String) {
-        this.kakaoRefreshToken = refreshToken
-    }
 
     fun modify(memberModifyDto: MemberModifyRequestDto) {
         this.nickname = memberModifyDto.nickname

--- a/backend/src/main/java/com/example/backend/domain/member/entity/Member.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/entity/Member.kt
@@ -18,15 +18,11 @@ class Member(
     var id: Long? = null
         protected set
 
-    @Column(name = "kakao_refresh_token")
-    var kakaoRefreshToken: String = ""
-
     constructor(kakaoUserInfoDto: KakaoUserInfoResponseDto) : this(
         kakaoId = kakaoUserInfoDto.id,
         nickname = kakaoUserInfoDto.properties.nickname,
         email = kakaoUserInfoDto.kakaoAccount.email
     )
-
 
     fun modify(memberModifyDto: MemberModifyRequestDto) {
         this.nickname = memberModifyDto.nickname

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.kt
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.kt
@@ -52,7 +52,7 @@ class MemberService(
 
     @Transactional
     fun join(kakaoUserInfoDto: KakaoUserInfoResponseDto) {
-        memberRepository.save(Member.of(kakaoUserInfoDto))
+        memberRepository.save(Member(kakaoUserInfoDto))
     }
 
     @Transactional
@@ -68,7 +68,7 @@ class MemberService(
         )
 
         cookieService.addAccessTokenToCookie(reissuedAccessToken, response)
-        return MemberInfoDto.of(member)
+        return MemberInfoDto(member)
     }
 
     fun findMemberInfoDtosByNickname(nickname: String): List<MemberInfoDto> {

--- a/backend/src/main/java/com/example/backend/domain/vote/dto/MostVotedLocationDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/vote/dto/MostVotedLocationDto.kt
@@ -1,8 +1,10 @@
 package com.example.backend.domain.vote.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class MostVotedLocationDto(
-    val location : String,
-    val address: String,
-    val latitude: Double,
-    val longitude: Double
+    @JsonProperty("location") val location: String,
+    @JsonProperty("address") val address: String,
+    @JsonProperty("latitude") val latitude: Double,
+    @JsonProperty("longitude") val longitude: Double
 )

--- a/backend/src/main/java/com/example/backend/domain/vote/dto/VoteResponseDto.kt
+++ b/backend/src/main/java/com/example/backend/domain/vote/dto/VoteResponseDto.kt
@@ -1,14 +1,23 @@
 package com.example.backend.domain.vote.dto
 
 import com.example.backend.domain.vote.entity.Vote
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 data class VoteResponseDto(
+    @JsonProperty("id")
     val id: Long?,
+    @JsonProperty("location")
     val location: String,
+    @JsonProperty("address")
     val address: String,
+    @JsonProperty("latitude")
     val latitude: Double,
+    @JsonProperty("longitude")
     val longitude: Double,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty("createdAt")
     val createdAt: LocalDateTime?
 ) {
     companion object {

--- a/backend/src/main/java/com/example/backend/domain/vote/service/VoteService.kt
+++ b/backend/src/main/java/com/example/backend/domain/vote/service/VoteService.kt
@@ -8,7 +8,8 @@ import com.example.backend.domain.vote.entity.Vote
 import com.example.backend.domain.vote.repository.VoteRepository
 import com.example.backend.domain.voter.repository.VoterRepository
 import jakarta.persistence.EntityNotFoundException
-import jakarta.validation.Valid
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -56,6 +57,7 @@ class VoteService(
         return VoteResponseDto.toDto(savedVote)
     }
 
+    @Cacheable(value = ["votes"], key = "#groupId")
     fun findAllByGroupId(groupId: Long): List<VoteResponseDto> {
         return voteRepository.findAllByGroupId(groupId)
             .map { VoteResponseDto.toDto(it) }
@@ -68,6 +70,7 @@ class VoteService(
     }
 
     @Transactional
+    @CacheEvict(value = ["votes"], key = "#groupId")
     fun modifyVote(groupId: Long, voteId: Long, requestDto: VoteRequestDto): VoteResponseDto {
         // 존재 확인만 함
         voteRepository.findByIdAndGroupId(voteId, groupId)
@@ -88,6 +91,7 @@ class VoteService(
         return VoteResponseDto.toDto(updatedVote)
     }
 
+    @CacheEvict(value = ["votes"], key = "#groupId")
     fun deleteVote(groupId: Long, voteId: Long) {
         val vote = voteRepository.findByIdAndGroupId(voteId, groupId)
             .orElseThrow { EntityNotFoundException("Vote not found") }

--- a/backend/src/main/java/com/example/backend/global/advice/GlobalControllerAdvice.kt
+++ b/backend/src/main/java/com/example/backend/global/advice/GlobalControllerAdvice.kt
@@ -8,7 +8,6 @@ import com.example.backend.domain.voter.exception.VoterException
 import com.example.backend.global.exception.GlobalErrorCode
 import com.example.backend.global.exception.GlobalException
 import com.example.backend.global.response.ErrorResponse
-import com.example.backend.global.response.ErrorResponse.Companion.of
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolation
 import jakarta.validation.ConstraintViolationException
@@ -50,7 +49,7 @@ class GlobalControllerAdvice {
         })
 
         return ResponseEntity.status(ex.statusCode.value()).body(
-            ErrorResponse.of(
+            ErrorResponse(
                 GlobalErrorCode.NOT_VALID.message,
                 GlobalErrorCode.NOT_VALID.code,
                 request.requestURI,
@@ -73,7 +72,7 @@ class GlobalControllerAdvice {
         })
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ErrorResponse.of(
+            ErrorResponse(
                 GlobalErrorCode.NOT_VALID.message,
                 GlobalErrorCode.NOT_VALID.code,
                 request.requestURI,
@@ -85,42 +84,42 @@ class GlobalControllerAdvice {
     @ExceptionHandler(GroupException::class)
     fun handleGroupException(ex: GroupException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(ex.status)
-            .body(ErrorResponse.of(ex.message, ex.code, request.requestURI))
+            .body(ErrorResponse(ex.message, ex.code, request.requestURI))
     }
 
     @ExceptionHandler(GlobalException::class)
     fun handleGlobalException(ex: GlobalException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(ex.status)
-            .body(ErrorResponse.of(ex.message, ex.code, request.requestURI))
+            .body(ErrorResponse(ex.message, ex.code, request.requestURI))
     }
 
     @ExceptionHandler(AdminException::class)
     fun handleAdminException(ex: AdminException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(ex.status)
-            .body(ErrorResponse.of(ex.message, ex.code, request.requestURI))
+            .body(ErrorResponse(ex.message, ex.code, request.requestURI))
     }
 
     @ExceptionHandler(CategoryException::class)
     fun handleCategoryException(ex: CategoryException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(ex.status)
-            .body(ErrorResponse.of(ex.message, ex.code, request.requestURI))
+            .body(ErrorResponse(ex.message, ex.code, request.requestURI))
     }
 
     @ExceptionHandler(MemberException::class)
     fun handleMemberException(ex: MemberException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(ex.status)
-            .body(ErrorResponse.of(ex.message, ex.code, request.requestURI))
+            .body(ErrorResponse(ex.message, ex.code, request.requestURI))
     }
 
     @ExceptionHandler(VoterException::class)
     fun handleVoterException(ex: VoterException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(ex.status)
-            .body(ErrorResponse.of(ex.message!!, ex.code, request.requestURI))
+            .body(ErrorResponse(ex.message, ex.code, request.requestURI))
     }
 
     @ExceptionHandler(Exception::class)
     fun handleVoterException(ex: Exception, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ErrorResponse.of(ex.message ?: "UNKNOWN_ERROR", "500", request.requestURI))
+            .body(ErrorResponse(ex.message ?: "UNKNOWN_ERROR", "500", request.requestURI))
     }
 }

--- a/backend/src/main/java/com/example/backend/global/auth/jwt/MemberAuthFilter.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/jwt/MemberAuthFilter.kt
@@ -9,7 +9,7 @@ import com.example.backend.global.auth.service.CustomUserDetailService
 import com.example.backend.global.auth.util.JwtUtil
 import com.example.backend.global.auth.util.TokenProvider
 import com.example.backend.global.redis.service.RedisService
-import com.example.backend.global.response.ErrorResponse.Companion.of
+import com.example.backend.global.response.ErrorResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
@@ -151,7 +151,7 @@ class MemberAuthFilter(
         response.status = ex.status.value()
         response.contentType = "application/json;charset=UTF-8"
 
-        val errorResponse = of(ex.message, ex.code, request.requestURI)
+        val errorResponse = ErrorResponse(ex.message, ex.code, request.requestURI)
         objectMapper.writeValue(response.writer, errorResponse)
     }
 

--- a/backend/src/main/java/com/example/backend/global/auth/kakao/controller/KakaoAuthController.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/kakao/controller/KakaoAuthController.kt
@@ -60,8 +60,10 @@ class KakaoAuthController(
 
         // 카카오에서 인가 토큰이 아닌 에러를 반환할 시 홈페이지로 리다이렉트 및 에러 메세지 응답
         if (error != null) {
-            val errorResponse = ErrorResponse.of(
-                errorDescription ?: "UNKNOWN_ERROR", "400-$error", request.requestURI
+            val errorResponse = ErrorResponse(
+                message = errorDescription ?: "UNKNOWN_ERROR",
+                code = "400-$error",
+                requestUri = request.requestURI
             )
 
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).headers(headers)

--- a/backend/src/main/java/com/example/backend/global/auth/kakao/controller/KakaoAuthController.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/kakao/controller/KakaoAuthController.kt
@@ -99,7 +99,7 @@ class KakaoAuthController(
 
         return ResponseEntity.status(HttpStatus.FOUND)
             .headers(headers)
-            .body(ApiResponse.of<Any>("성공적으로 로그인 되었습니다. nickname : " + loginDto.nickname))
+            .body(ApiResponse<Any>("성공적으로 로그인 되었습니다. nickname : " + loginDto.nickname))
     }
 
     /**
@@ -130,6 +130,6 @@ class KakaoAuthController(
         headers.location = URI.create(clientBaseUrl)
 
         return ResponseEntity.status(HttpStatus.FOUND)
-            .headers(headers).body(ApiResponse.of("성공적으로 로그아웃 되었습니다."))
+            .headers(headers).body(ApiResponse("성공적으로 로그아웃 되었습니다."))
     }
 }

--- a/backend/src/main/java/com/example/backend/global/auth/kakao/service/KakaoAuthService.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/kakao/service/KakaoAuthService.kt
@@ -156,10 +156,10 @@ class KakaoAuthService(
             redisService.addBlackList(refreshToken, jwtUtil.getRefreshTokenExpirationTime())
             saveRefreshToken(kakaoTokenDto.refreshToken, kakaoMemberId)
 
-            return MemberTokenReissueDto.of(memberInfoDto, kakaoTokenDto.refreshToken)
+            return MemberTokenReissueDto(memberInfoDto, kakaoTokenDto.refreshToken)
         }
 
-        return MemberTokenReissueDto.of(memberInfoDto, refreshToken)
+        return MemberTokenReissueDto(memberInfoDto, refreshToken)
     }
 
     private fun saveRefreshToken(refreshToken: String, kakaoMemberId: Long) {

--- a/backend/src/main/java/com/example/backend/global/auth/service/CustomUserDetailService.kt
+++ b/backend/src/main/java/com/example/backend/global/auth/service/CustomUserDetailService.kt
@@ -21,7 +21,7 @@ class CustomUserDetailService(
     @Throws(UsernameNotFoundException::class)
     override fun loadUserByUsername(username: String): CustomUserDetails {
         val member = memberService.findById(username.toLong())
-        return CustomUserDetails(MemberInfoDto.of(member))
+        return CustomUserDetails(MemberInfoDto(member))
     }
 
     fun loadUserByAccessToken(accessToken: String): CustomUserDetails {

--- a/backend/src/main/java/com/example/backend/global/config/CacheConfig.kt
+++ b/backend/src/main/java/com/example/backend/global/config/CacheConfig.kt
@@ -1,0 +1,54 @@
+package com.example.backend.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.cache.RedisCacheWriter
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+/**
+ * CacheConfig
+ * <p></p>
+ * @author 100minha
+ */
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val objectMapper = ObjectMapper()  // Jackson의 ObjectMapper 인스턴스를 생성 (JSON 직렬화/역직렬화에 사용)
+            .registerModules(JavaTimeModule())  // Java 8 날짜/시간(`java.time.LocalDateTime` 등)을 처리할 수 있도록 `JavaTimeModule` 등록
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)  // 날짜/시간을 타임스탬프(숫자)로 변환하지 않고 문자열(예: "2025-03-10T16:44:21")로 변환하도록 설정
+            .apply {
+                activateDefaultTyping(
+                    polymorphicTypeValidator, // 직렬화/역직렬화 시 다형성(polymorphism) 처리를 위한 유효성 검사기 (보안 목적)
+                    ObjectMapper.DefaultTyping.NON_FINAL // final이 아닌 클래스들에 대해 기본 타입 정보를 포함하여 직렬화하도록 설정
+                )
+            }
+
+        val genericJackson2JsonRedisSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
+
+        val cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory)
+        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(genericJackson2JsonRedisSerializer)
+            ) // Value Serializer 변경
+            .entryTtl(Duration.ofMinutes(10L))
+
+        return RedisCacheManager.builder(cacheWriter)
+            .cacheDefaults(cacheConfig)
+            .build()
+    }
+}

--- a/backend/src/main/java/com/example/backend/global/response/ApiResponse.kt
+++ b/backend/src/main/java/com/example/backend/global/response/ApiResponse.kt
@@ -9,17 +9,6 @@ data class ApiResponse<T>(
     val message: String,
     val data: T? = null
 ) {
-    companion object {
-        fun <T> of(message: String): ApiResponse<T> {
-            return ApiResponse(message = message)
-        }
 
-        fun <T> of(data: T): ApiResponse<T> {
-            return ApiResponse(message = "Success", data = data)
-        }
-
-        fun <T> of(message: String, data: T): ApiResponse<T> {
-            return ApiResponse(message = message, data = data)
-        }
-    }
+    constructor(data: T) : this(message = "Success", data = data)
 }

--- a/backend/src/main/java/com/example/backend/global/response/ErrorResponse.kt
+++ b/backend/src/main/java/com/example/backend/global/response/ErrorResponse.kt
@@ -20,35 +20,4 @@ data class ErrorResponse(
         val field: String,  // 에러가 발생한 필드명
         val message: String? = "" // 해당 필드의 에러 메시지
     )
-
-    companion object {
-        /**
-         * Validation 예외 발생 시 응답 때 사용할 팩토리 메서드
-         * @param message    // 예외 메세지
-         * @param code    // 예외 상태 코드
-         * @param errors    // 필드별 에러 메세지
-         */
-        fun of(message: String, code: String, requestUri: String, errors: List<ValidationError>): ErrorResponse {
-            return ErrorResponse(
-                message = message,
-                code = code,
-                requestUri = requestUri,
-                errors = errors
-            )
-        }
-
-        /**
-         * 이외에 FieldError를 포함하지 않는 예외 발생 시 사용할 팩토리 메서드
-         * @param message    // 예외 메세지
-         * @param code    // 예외 상태 코드
-         */
-        @JvmStatic
-		fun of(message: String, code: String, requestUri: String): ErrorResponse {
-            return ErrorResponse(
-                message = message,
-                code = code,
-                requestUri = requestUri
-            )
-        }
-    }
 }

--- a/backend/src/test/java/com/example/backend/domain/category/controller/CategoryControllerTest.kt
+++ b/backend/src/test/java/com/example/backend/domain/category/controller/CategoryControllerTest.kt
@@ -6,6 +6,7 @@ import com.example.backend.domain.category.entity.Category
 import com.example.backend.domain.category.entity.CategoryType
 import com.example.backend.domain.category.repository.CategoryRepository
 import com.example.backend.domain.category.service.CategoryService
+import com.example.backend.global.redis.service.RedisService
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import jakarta.servlet.http.Cookie
@@ -44,6 +45,9 @@ class CategoryControllerTest {
 
     @Autowired
     private lateinit var categoryService: CategoryService
+
+    @Autowired
+    private lateinit var redisService: RedisService
 
     @PersistenceContext
     private lateinit var em: EntityManager
@@ -110,6 +114,8 @@ class CategoryControllerTest {
             .andExpect(jsonPath("$.id").exists())
             .andExpect(jsonPath("$.type").value("HOBBY"))
             .andExpect(jsonPath("$.name").value("새로운 취미 카테고리"))
+
+        redisService.delete(refreshToken)
     }
 
     @Test
@@ -167,6 +173,8 @@ class CategoryControllerTest {
             .andExpect(jsonPath("$.id").value(1L))
             .andExpect(jsonPath("$.type").value("EXERCISE"))
             .andExpect(jsonPath("$.name").value("수정된 카테고리"))
+
+        redisService.delete(refreshToken)
     }
 
     @Test
@@ -184,6 +192,8 @@ class CategoryControllerTest {
         resultActions.andExpect(handler().handlerType(CategoryController::class.java))
             .andExpect(handler().methodName("deleteCategory"))
             .andExpect(status().isOk)
+
+        redisService.delete(refreshToken)
     }
 
     @Test

--- a/backend/src/test/java/com/example/backend/domain/category/controller/CategoryControllerTest.kt
+++ b/backend/src/test/java/com/example/backend/domain/category/controller/CategoryControllerTest.kt
@@ -5,7 +5,7 @@ import com.example.backend.domain.admin.repository.AdminRepository
 import com.example.backend.domain.category.entity.Category
 import com.example.backend.domain.category.entity.CategoryType
 import com.example.backend.domain.category.repository.CategoryRepository
-import com.example.backend.domain.member.repository.MemberRepository
+import com.example.backend.domain.category.service.CategoryService
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import jakarta.servlet.http.Cookie
@@ -40,10 +40,10 @@ class CategoryControllerTest {
     private lateinit var mockMvc: MockMvc
 
     @Autowired
-    private lateinit var memberRepository: MemberRepository
+    private lateinit var categoryRepository: CategoryRepository
 
     @Autowired
-    private lateinit var categoryRepository: CategoryRepository
+    private lateinit var categoryService: CategoryService
 
     @PersistenceContext
     private lateinit var em: EntityManager
@@ -200,6 +200,7 @@ class CategoryControllerTest {
     @Test
     @DisplayName("카테고리 목록이 없을 때 조회")
     fun getCategoryListEmptyTest() {
+        categoryService.delete(1L)  // redis캐시 무효화를 위해 서비스 삭제 메서드 실행
         categoryRepository.deleteAll()
 
         val resultActions: ResultActions = mockMvc.perform(

--- a/backend/src/test/java/com/example/backend/domain/member/repository/MemberRepositoryTest.kt
+++ b/backend/src/test/java/com/example/backend/domain/member/repository/MemberRepositoryTest.kt
@@ -158,7 +158,7 @@ class MemberRepositoryTest {
     @DisplayName("findMemberInfoDtoById 성공 테스트")
     fun findMemberInfoDtoByIdSuccessTest() {
         // given
-        val memberInfoDtoOfMember = MemberInfoDto.of(member)
+        val memberInfoDtoOfMember = MemberInfoDto(member)
         val optionalMemberInfoDto = memberRepository.findMemberInfoDtoById(1L)
 
         // when

--- a/backend/src/test/java/com/example/backend/global/config/CacheConfig.kt
+++ b/backend/src/test/java/com/example/backend/global/config/CacheConfig.kt
@@ -1,0 +1,57 @@
+package com.example.backend.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.cache.RedisCacheWriter
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+/**
+ * CacheConfig
+ * <p></p>
+ * @author 100minha
+ */
+@Configuration
+@EnableCaching
+@Profile("test")
+class CacheConfig {
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val objectMapper = ObjectMapper()  // Jackson의 ObjectMapper 인스턴스를 생성 (JSON 직렬화/역직렬화에 사용)
+            .registerModules(JavaTimeModule())  // Java 8 날짜/시간(`java.time.LocalDateTime` 등)을 처리할 수 있도록 `JavaTimeModule` 등록
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)  // 날짜/시간을 타임스탬프(숫자)로 변환하지 않고 문자열(예: "2025-03-10T16:44:21")로 변환하도록 설정
+            .apply {
+                activateDefaultTyping(
+                    polymorphicTypeValidator, // 직렬화/역직렬화 시 다형성(polymorphism) 처리를 위한 유효성 검사기 (보안 목적)
+                    ObjectMapper.DefaultTyping.NON_FINAL // final이 아닌 클래스들에 대해 기본 타입 정보를 포함하여 직렬화하도록 설정
+                )
+            }
+
+        val genericJackson2JsonRedisSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
+
+        val cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory)
+        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    genericJackson2JsonRedisSerializer
+                )
+            ) // Value Serializer 변경
+            .entryTtl(Duration.ofSeconds(3L))   // 캐시 만료 시간 3초
+
+        return RedisCacheManager.builder(cacheWriter)
+            .cacheDefaults(cacheConfig)
+            .build()
+    }
+}

--- a/backend/src/test/java/com/example/backend/global/redis/service/RedisServiceTest.kt
+++ b/backend/src/test/java/com/example/backend/global/redis/service/RedisServiceTest.kt
@@ -1,6 +1,5 @@
-package com.example.backend.domain.redis.service
+package com.example.backend.global.redis.service
 
-import com.example.backend.global.redis.service.RedisService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach

--- a/backend/src/test/java/com/example/backend/global/redis/service/RedisServiceTest.kt
+++ b/backend/src/test/java/com/example/backend/global/redis/service/RedisServiceTest.kt
@@ -21,7 +21,7 @@ class RedisServiceTest {
     @BeforeEach
     fun init() {
         // 실제 Redis 서버에 토큰 저장
-        redisService.save(refreshToken, "admin", 3600000L)
+        redisService.save(refreshToken, "admin", 5L)
     }
 
     @Test
@@ -34,7 +34,7 @@ class RedisServiceTest {
     @Test
     @DisplayName("리프레시 토큰 블랙리스트 테스트")
     fun refreshTokenShouldBeDeleted() {
-        redisService.addBlackList(refreshToken, 3600000L)
+        redisService.addBlackList(refreshToken, 5L)
         val storedValue = redisService.get(refreshToken)
         assertThat(storedValue).isEqualTo("blacklisted")
     }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 카테고리 전체 조회 및 특정 그룹의 투표 조회 캐싱

### 자바식 팩토리 메서드 제거

### lombok 의존성 삭제

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- [x] 자바식 팩토리 메서드 제거
- [x] lombok의존성 삭제
- [x] 기존에 사용하던 logger는 loggerFactory로 대체
- [x] 카테고리 전체 조회 캐싱
- [x] 카테고리 수정, 삭제, 추가 시 캐시 데이터 만료
- [x] 그룹의 투표 옵션도 수정이 거의 없기에 캐싱 적용
- [x] 캐시 설정 클래스 작성(테스트용은 만료기간 3초)

